### PR TITLE
Provide an equivalent to the C# is operator

### DIFF
--- a/Mono.mscorlib/Mono.mscorlib/Categories/System_Object+mscorlib.h
+++ b/Mono.mscorlib/Mono.mscorlib/Categories/System_Object+mscorlib.h
@@ -19,6 +19,13 @@
 + (System_Type *)db_getType;
 
 /**
+ 
+ Mirrors the functionality provided by the C# `is` operator. Validates if the passed in class is System_Object or a subclass of System_Object and then calls `IsAssignableFrom` on the instance of the receiver, using the `System_Type` of the passed in class.
+ 
+ */
+- (BOOL)db_is:(Class)otherClass;
+
+/**
 
  Create an instance of the receiver's core class with a generic type parameters.
  

--- a/Mono.mscorlib/Mono.mscorlib/Categories/System_Object+mscorlib.m
+++ b/Mono.mscorlib/Mono.mscorlib/Categories/System_Object+mscorlib.m
@@ -23,6 +23,24 @@
     return [[System_Type alloc] initWithMonoObject:(MonoObject *)monoReflectionType];
 }
 
+- (BOOL)db_is:(Class)aClass
+{
+    if (aClass != System_Object.class &&
+        ![aClass isSubclassOfClass:System_Object.class]) {
+        return NO;
+    }
+    
+    System_Type* systemTypeOfAClass = aClass.db_getType;
+    
+    if (!systemTypeOfAClass) {
+        return NO;
+    }
+    
+    BOOL isAssignable = [self.db_getType isAssignableFrom_withC:systemTypeOfAClass];
+    
+    return isAssignable;
+}
+
 #pragma mark -
 #pragma mark Generic factory convenience methods
 


### PR DESCRIPTION
This PR adds a `db_is` method to `System_Object` which basically allows you to do the same as the C# `is` operator: check whether an instance of an object is compatible with a given type.

This is useful in scenarios where `isKindOfClass:` doesn't work. For instance when the object you have at hand is a managed interface and you need to find out whether it's of a specific type.