### PR TITLE
Allow to use an existing environment (aka don't call mono_jit_init)

### DIFF
--- a/Framework/XCode/DBManagedEnvironment.h
+++ b/Framework/XCode/DBManagedEnvironment.h
@@ -100,6 +100,8 @@ extern NSString * const DBNoteManagedEnvironmentLoaded;
 
 + (DBManagedEnvironment *)defaultEnvironmentWithName:(const char *)domainName;
 
++ (DBManagedEnvironment *)existingEnvironment;
+
 - (id)initWithDomainName:(const char *)domainName;
 
 /*!


### PR DESCRIPTION
I'm currently experimenting with integrating Dubrovnik into an existing, embedded mono environment. Specifically, I'm mixing Monobjc with Dubrovnik.

For this purpose, I needed a way to NOT call `mono_jit_init` as Monobjc already initializes mono before Dubrovnik is involved.

To make this work, I added a new class method `+[DBManagedEnvironment existingEnvironment]`.
So if you already have an initialized mono environment, you can now do this: `DBManagedEnvironment.currentEnvironment = DBManagedEnvironment.existingEnvironment` and have Dubrovnik *recycle* the existing environment.