### PR TITLE
Added false/true to unsafe ObjC class method names

### DIFF
--- a/dotNET/Dubrovnik.Tools/Dubrovnik.Tools/Net2ObjC.ObjC.cs
+++ b/dotNET/Dubrovnik.Tools/Dubrovnik.Tools/Net2ObjC.ObjC.cs
@@ -49,16 +49,16 @@ namespace Dubrovnik.Tools {
 			return acronym;
 		}
 
-		public List<string> UnsafeObjCClassMethodNames() {
-			return new List<string> {
-									"load",	// +load will get called when the unmanaged framework loads. The managed code will likely not expect this.
-									"initialize",
-									"alloc",
-									"new",
-									"class",
-									"superclass"
-									};
-		}
+		public readonly List<string> UnsafeObjCClassMethodNames = new List<string>() {
+			"load",	// +load will get called when the unmanaged framework loads. The managed code will likely not expect this.
+			"initialize",
+			"alloc",
+			"new",
+			"class",
+			"superclass",
+			"false",
+			"true",
+		};
 
 		public List<string> UnsafeObjCMethodNames() {
 			return new List<string> {

--- a/dotNET/Dubrovnik.Tools/Dubrovnik.Tools/Output/ObjCAccessor.cs
+++ b/dotNET/Dubrovnik.Tools/Dubrovnik.Tools/Output/ObjCAccessor.cs
@@ -38,7 +38,7 @@ namespace Dubrovnik.Tools.Output
                 ObjCMethodType = "+";
 
                 // decorate class accessor method names known to be unsafe
-                if (n2c.UnsafeObjCClassMethodNames().Contains(GetterName)) {
+                if (n2c.UnsafeObjCClassMethodNames.Contains(GetterName)) {
                     GetterName += "_";
                     SetterName += "_";
                 }

--- a/dotNET/Dubrovnik.Tools/Dubrovnik.Tools/Output/ObjCMethod.cs
+++ b/dotNET/Dubrovnik.Tools/Dubrovnik.Tools/Output/ObjCMethod.cs
@@ -65,7 +65,7 @@ namespace Dubrovnik.Tools.Output
                 ObjCMethodType = "+";
                 if (facet.Parameters.Count == 0) {
                     // decorate class method names known to be unsafe
-                    if (n2c.UnsafeObjCClassMethodNames().Contains(ObjCMethodName)) {
+                    if (n2c.UnsafeObjCClassMethodNames.Contains(ObjCMethodName)) {
                         ObjCMethodName += "_";
                     }
                 }


### PR DESCRIPTION
A managed enum like this:
```
public enum TriStateValue {
    Uninitialized = -1,
    False = 0,
    True = 1 
}
```

would, prior to this PR generate code like this:

```
+ (enumremojoApi_TriStateValue)false;
+ (enumremojoApi_TriStateValue)true;
+ (enumremojoApi_TriStateValue)uninitialized;
```

which is illegal in Objective-C and fails at compilation.

This PR puts `false` and `true` on the unsafe class method name list to prevent this.

Also included: Create list of unsafe Objective-C class method names only once instead of creating a new copy of the list every time `UnsafeObjCClassMethodNames()` was called.