### PR TITLE
Fixed unboxing of block parameters

### DIFF
--- a/dotNET/Dubrovnik.Tools/Dubrovnik.Tools/Net2ObjC.Event.cs
+++ b/dotNET/Dubrovnik.Tools/Dubrovnik.Tools/Net2ObjC.Event.cs
@@ -165,10 +165,10 @@ namespace Dubrovnik.Tools
 				for (int idx = 0; idx < event_.ObjCEventBlockParameterCount; idx++) {
 					string parameterGetter = $"parameters[{idx}]";
 
-					string unboxingCallFormat = event_.ObjCEventBlockParametersUnboxingCalls[idx];
+					string getterFormat = event_.ObjCEventBlockParameterGetters[idx];
 
-					if (!string.IsNullOrEmpty(unboxingCallFormat)) {
-						parameterGetter = string.Format(unboxingCallFormat, parameterGetter);
+					if (!string.IsNullOrEmpty(getterFormat)) {
+						parameterGetter = string.Format(getterFormat, "[" + parameterGetter + " monoObject]");
 					}
 
 					Write(parameterGetter);

--- a/dotNET/Dubrovnik.Tools/Dubrovnik.Tools/Net2ObjC.Type.cs
+++ b/dotNET/Dubrovnik.Tools/Dubrovnik.Tools/Net2ObjC.Type.cs
@@ -60,15 +60,6 @@ namespace Dubrovnik.Tools {
 				"BOOL"
 			};
 
-			private static readonly Dictionary<string, string> _UnboxingMethods = new Dictionary<string, string>() {
-				{ "char", "charValue" }, { "unichar", "unsignedCharValue" },
-				{ "int8_t", "charValue" }, { "int16_t", "shortValue" }, { "int32_t", "intValue" }, { "int64_t", "longValue" },
-				{ "uint8_t", "unsignedCharValue" }, { "uint16_t", "unsignedShortValue" }, { "uint32_t", "unsignedIntValue" }, { "uint64_t", "unsignedLongValue" },
-				{ "short", "shortValue" }, { "long", "longValue" },
-				{ "double", "doubleValue" }, { "float", "floatValue" },
-				{ "BOOL", "boolValue" },
-			};
-
 			public ManagedTypeAssociation ManagedTypeAssociate { get; set; }
 			public string ObjCType { get; set; }
 			public string GetterFormat { get; set; }
@@ -134,25 +125,6 @@ namespace Dubrovnik.Tools {
 				}
 			}
 			public string SetterMethod { get; set; }
-
-			public static string ObjCUnboxingMethodCallFormat(string objcType)
-			{
-				if (!IsNumericType(objcType)) {
-					return string.Empty;
-				}
-                string unboxingMethodCall = null;
-                if (_UnboxingMethods.TryGetValue(objcType, out unboxingMethodCall) &&
-					!string.IsNullOrEmpty(unboxingMethodCall)) {
-					return "[{0} " + unboxingMethodCall + "]";
-				}
-
-				return string.Empty;
-			}
-
-			public string ObjCUnboxingMethodCallFormat()
-			{
-				return ObjCUnboxingMethodCallFormat(ObjCType);
-			}
 		}
 
 		//

--- a/dotNET/Dubrovnik.Tools/Dubrovnik.Tools/Output/ObjCEvent.cs
+++ b/dotNET/Dubrovnik.Tools/Dubrovnik.Tools/Output/ObjCEvent.cs
@@ -13,7 +13,7 @@ namespace Dubrovnik.Tools.Output
         public string ObjCEventBlockTypeName { get; private set; }
         public string ObjCEventBlockTypeMinimalName { get; private set; }
         public string ObjCEventBlockParameters { get; private set; }
-		public string[] ObjCEventBlockParametersUnboxingCalls { get; private set; }
+		public string[] ObjCEventBlockParameterGetters { get; private set; }
 		public int ObjCEventBlockParameterCount { get; private set; }
 		public string ObjCTypeDecl { get; private set; }
         public string ObjCType { get; private set; }
@@ -51,7 +51,7 @@ namespace Dubrovnik.Tools.Output
             ObjCEventBlockTypeName = $"{interfaceFacet.ObjCFacet.Type}{eventBlockName}";
             ObjCEventBlockTypeMinimalName = $"{n2c.ObjCMinimalIdentifierFromManagedIdentifier(interfaceFacet.Type)}{eventBlockName}";
 			ObjCEventBlockParameterCount = eventFacet.Parameters.Count;
-			ObjCEventBlockParametersUnboxingCalls = new string[ObjCEventBlockParameterCount];
+			ObjCEventBlockParameterGetters = new string[ObjCEventBlockParameterCount];
 
 			// process the parameters
 			ProcessParameters(n2c, eventFacet, options);
@@ -125,7 +125,7 @@ namespace Dubrovnik.Tools.Output
                     objCParameterIsObject = n2c.ObjCRepresentationIsObject(parameter);
                 }
 
-				ObjCEventBlockParametersUnboxingCalls[idx] = objCTypeAssociate?.ObjCUnboxingMethodCallFormat() ?? string.Empty;
+				ObjCEventBlockParameterGetters[idx] = objCTypeAssociate?.GetterFormat ?? string.Empty;
 
                 // if parameter is an interface then use adoption conforming type ie: id <typename>
                 if (parameter.IsInterface) {


### PR DESCRIPTION
Block parameters now get their getters from type associations if available.