### PR TITLE
Added "release" to unsafe ObjC method names

### DIFF
--- a/dotNET/Dubrovnik.Tools/Dubrovnik.Tools/Net2ObjC.ObjC.cs
+++ b/dotNET/Dubrovnik.Tools/Dubrovnik.Tools/Net2ObjC.ObjC.cs
@@ -60,11 +60,10 @@ namespace Dubrovnik.Tools {
 			"true",
 		};
 
-		public List<string> UnsafeObjCMethodNames() {
-			return new List<string> {
-									"init" // methods beginning with init are expected to return a type related to the receiver
-			};
-		}
+		public readonly List<string> UnsafeObjCMethodNames = new List<string>() {
+			"init", // methods beginning with init are expected to return a type related to the receiver
+			"release"
+		};
 
 		//
 		// ObjCNonAssociatedTypeIsNSObject

--- a/dotNET/Dubrovnik.Tools/Dubrovnik.Tools/Net2ObjC.ObjC.cs
+++ b/dotNET/Dubrovnik.Tools/Dubrovnik.Tools/Net2ObjC.ObjC.cs
@@ -61,7 +61,6 @@ namespace Dubrovnik.Tools {
 		};
 
 		public readonly List<string> UnsafeObjCMethodNames = new List<string>() {
-			"init", // methods beginning with init are expected to return a type related to the receiver
 			"release"
 		};
 

--- a/dotNET/Dubrovnik.Tools/Dubrovnik.Tools/Output/ObjCMethod.cs
+++ b/dotNET/Dubrovnik.Tools/Dubrovnik.Tools/Output/ObjCMethod.cs
@@ -74,7 +74,7 @@ namespace Dubrovnik.Tools.Output
                 ObjCMethodType = "-";
 
                 // decorate instance method names known to be unsafe
-                if (facet.Type != "System.Void" && n2c.UnsafeObjCMethodNames().Any(p => ObjCMethodName.StartsWith(p, false, null))) {
+                if (facet.Type != "System.Void" && n2c.UnsafeObjCMethodNames.Any(p => ObjCMethodName.StartsWith(p, false, null))) {
                     ObjCMethodName = "db_" + ObjCMethodName;
                 }
             }

--- a/dotNET/Dubrovnik.Tools/Dubrovnik.Tools/Output/ObjCMethod.cs
+++ b/dotNET/Dubrovnik.Tools/Dubrovnik.Tools/Output/ObjCMethod.cs
@@ -74,7 +74,8 @@ namespace Dubrovnik.Tools.Output
                 ObjCMethodType = "-";
 
                 // decorate instance method names known to be unsafe
-                if (facet.Type != "System.Void" && n2c.UnsafeObjCMethodNames.Any(p => ObjCMethodName.StartsWith(p, false, null))) {
+                if (n2c.UnsafeObjCMethodNames.Any(p => ObjCMethodName.StartsWith(p, false, null)) ||
+                    (facet.Type != "System.Void" && ObjCMethodName.StartsWith("init", false, null))) { // methods beginning with init are expected to return a type related to the receiver
                     ObjCMethodName = "db_" + ObjCMethodName;
                 }
             }


### PR DESCRIPTION
A managed method `void Release()` would previously generate a Objective-C method `- (void)release` which is forbidden in ARC. It now generates as `- (void)db_release`.

Also included: Create list of unsafe Objective-C method names only once instead of creating a new copy of the list every time `UnsafeObjCMethodNames()` was called.